### PR TITLE
Fix no-checkout GitHub Release publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,10 +115,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber
           else
             gh release create "$GITHUB_REF_NAME" dist/* \
+              --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
               --title "$GITHUB_REF_NAME" \
               --generate-notes \

--- a/tests/test_documentation_integrity.py
+++ b/tests/test_documentation_integrity.py
@@ -150,6 +150,7 @@ def test_release_and_tool_metadata_stay_synchronized() -> None:
     assert github_release["permissions"]["contents"] == "write"
     release_command = github_release["steps"][-1]["run"]
     assert 'gh release create "$GITHUB_REF_NAME" dist/*' in release_command
+    assert release_command.count('--repo "$GITHUB_REPOSITORY"') == 3
     assert "--verify-tag" in release_command
     assert "--generate-notes" in release_command
 


### PR DESCRIPTION
## Summary

- pass the explicit repository to all `gh release` commands in the no-checkout release job
- preserve idempotent release repair/upload behavior
- add a regression that requires repository targeting on view, upload, and create

## Context

The v0.6.3 verification and PyPI publish jobs succeeded, but the new GitHub Release job had no checkout and `gh release` therefore could not infer a repository. The v0.6.3 GitHub Release was repaired from PyPI artifacts after verifying their SHA-256 digests. This change prevents recurrence on future tags.

## Validation

- `uv run pytest -q tests/test_documentation_integrity.py`: 9 passed
- Ruff check/format: passed
- focused pre-commit hooks: passed
- explicit `gh release view --repo u9401066/pubmed-search-mcp`: passed